### PR TITLE
Change card layout and add styling

### DIFF
--- a/src/App/App.css
+++ b/src/App/App.css
@@ -30,7 +30,8 @@
   border-color: rgb(0,82,111);
   padding: 10px;
   margin: 10px; 
-  font-weight: 600; 
+  font-weight: 600;
+  /* font-size: .8em;    */
 }
 
 .err-msg {

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -8,6 +8,7 @@ import { Route, Switch } from 'react-router-dom';
 import { ReactComponent as NewsPaperImg } from '../assets/noun_Newspaper_3963888.svg';
 import { fetchArticles, fetchHomeArticles } from '../apiCalls';
 
+
 const App = () => {
   const [section, setSection] = useState('home');
   const [articles, setArticles] = useState([]);
@@ -41,8 +42,9 @@ const App = () => {
       setErr(err.message)
     })
   }
-
+  console.log(articles)
   return (
+    
     <div className="App">
       <header className="App-header">
         <h1 className="App-title">Fresh News Box</h1>

--- a/src/ArticleCard/ArticleCard.css
+++ b/src/ArticleCard/ArticleCard.css
@@ -1,12 +1,30 @@
 .card {
   padding: 5px; 
-  margin-bottom: 10px; 
-  box-shadow: 0 0 5px black; 
+  margin: 10px; 
+  box-shadow: 0px 0px 3px rgb(56, 61, 71);
+  flex-basis: 90%; 
+  max-width: 400px;  
 }
 
 .card-title {
-  margin: 0;  
+  font-size: 1.2em; 
+  margin: 5px;  
   color: rgb(0,82,111);
+}
+
+.card-img {
+  object-fit: cover; 
+}
+
+.card-content-container {
+  display: flex; 
+  justify-content: space-between;
+}
+
+.card-btn-date-container {
+  display: flex; 
+  flex-direction: column; 
+  justify-content: center;  
 }
 
 .expanded-card {

--- a/src/ArticleCard/ArticleCard.js
+++ b/src/ArticleCard/ArticleCard.js
@@ -3,23 +3,26 @@ import './ArticleCard.css';
 import { formatDate } from '../utility.js';
 import { Link } from 'react-router-dom';
 
-const ArticleCard = ({ title, publishDate, showDetails }) => {
+const ArticleCard = ({ title, publishDate, showDetails, img }) => {
   const cleanedDate = formatDate(publishDate)
   const formatTitle = encodeURIComponent(title)
   return (
     <article className="card">
-      <h2 className="card-title">{ title }</h2>
-      <div className="expanded-card">
-        <time className="card-date"><span className="card-date-intro">published:</span> { cleanedDate }</time>
-        <Link to={`/${formatTitle}`}>
-          <button 
-            className="button"
-            onClick={() => showDetails(title)}
-          >
-              EXPLORE MORE
-          </button>
-        </Link>
+      <div className="card-content-container">
+        <img className="card-img" src={img} alt={img.caption}/>
+        <div className="card-btn-date-container">
+          <Link to={`/${formatTitle}`}>
+            <button 
+              className="button"
+              onClick={() => showDetails(title)}
+            >
+                EXPLORE MORE
+            </button>
+          </Link>
+          <time className="card-date"><span className="card-date-intro">published:</span> { cleanedDate }</time>
+        </div>
       </div>
+      <h2 className="card-title">{ title }</h2>
     </article>
   )
 }

--- a/src/ArticleList/ArticleList.css
+++ b/src/ArticleList/ArticleList.css
@@ -13,7 +13,10 @@
 }
 
 .article-list {
-  padding-top: 90px; 
+  padding-top: 90px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;   
 }
 
 @media screen and (min-width: 1000px) {

--- a/src/ArticleList/ArticleList.js
+++ b/src/ArticleList/ArticleList.js
@@ -7,6 +7,7 @@ const ArticleList = ({ articles, showDetails, section, err }) => {
     return <ArticleCard
               key={i}
               id={Date.now()}
+              img={article.multimedia[2].url}
               title={article.title}
               publishDate={article.published_date}
               showDetails={showDetails}

--- a/src/NavBar/NavBar.js
+++ b/src/NavBar/NavBar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BiHomeAlt } from 'react-icons/bi';
-import { BiMenu } from 'react-icons/bi';
+import { FaRegNewspaper } from 'react-icons/fa';
 import { NavLink } from 'react-router-dom';
 import './NavBar.css';
 
@@ -19,7 +19,7 @@ const NavBar = ({ styleName }) => {
         activeClassName="active" 
         to="/sections"
       >
-        <BiMenu className="nav-icon"/>
+        <FaRegNewspaper className="nav-icon"/>
       </NavLink>
     </nav>
     


### PR DESCRIPTION
## What is being added/changed?
- the card layout includes pictures for better UX and draw to article
- The responsive design now includes a grid of cards

## How should this be tested?
- Images should now appear on each card, when expanded to desktop the grid of cards should display multiple columns. 

## future iterations?
- additional detail styling

## Linked Issues?
-N/A