### PR TITLE
Refactor/date conversion

### DIFF
--- a/cypress/integration/examples/news_box_spec.js
+++ b/cypress/integration/examples/news_box_spec.js
@@ -17,7 +17,7 @@ describe("Fresh News Box", () => {
 
     it("should display article cards", () => {
       cy.get('[data-cy=article-card]').first().should("contain", "Facebook Says Trump’s Ban Will Last at Least 2 Years")
-      .and("contain", "published: 2021-06-04").get("[data-cy=card-btn]").should("contain", "EXPLORE MORE")
+      .and("contain", "published: 06/04/2021").get("[data-cy=card-btn]").should("contain", "EXPLORE MORE")
       .get("[data-cy=card-img]").should("have.attr", "src").should("include", "https://static01.nyt.com/images/2021/06/04/business/04facebook/04facebook-thumbLarge.jpg");
     });
 

--- a/src/ArticleDetails/ArticleDetails.css
+++ b/src/ArticleDetails/ArticleDetails.css
@@ -8,6 +8,7 @@
   height: 200px;
   min-width: 200px; 
   box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
+  object-fit: cover; 
 }
 
 .article-abstract {

--- a/src/utility.js
+++ b/src/utility.js
@@ -1,5 +1,6 @@
 export const formatDate = (date) => {
-  const dateSplit = date.split('T')
-  return dateSplit[0]
+  const dateOnly = date.split('T')
+  const convertedDate = dateOnly[0].split('-')
+  return `${convertedDate[1]}/${convertedDate[2]}/${convertedDate[0]}`
 }
 


### PR DESCRIPTION
## What is being added/changed?
- The date conversion utility function now converts the date to american standard for better readability

## How should this be tested?
- The cards should all load the dates in proper format
- npm start, and visit localhost:3000/
## future iterations?
- adding the full publish time on the details pate

## Linked Issues?
